### PR TITLE
Content in pagination buttons and pause on click.

### DIFF
--- a/simple.carousel.js
+++ b/simple.carousel.js
@@ -24,13 +24,20 @@ $.fn.simplecarousel = function( params ) {
         pagination: false,
         paginationItem: function( index ) {
             return '';
-        }
+        },
+        pauseOnClick: false
     };
     var config = $.extend(defaults, params);
     
     // configure carousel ul and li
     var ul = $(this);
     var li = ul.children('li');
+    
+    if(config.pauseOnClick) {
+        li.bind('click', function () {
+            config.auto = false;
+        });
+    }
     
     config.items = li.length;
     
@@ -118,7 +125,7 @@ $.fn.simplecarousel = function( params ) {
             else
                 pagination.append('<li>' + config.paginationItem(i + 1) + '</li>');
         }
-        
+
         pagination.find('li').each(function(index, item) {
             $(this).click(function() {
                 slide(index,true);


### PR DESCRIPTION
I added two new options:
- pauseOnclick - A boolean that when `true` pauses the automatic sliding when user clicks in the current visible content. The default value is `false`.
- paginationItem - A function which takes the item index as paramter and returns a string which will fill the button element. The default value is `function( i ) { return ''; }`

I also created [one example](https://gist.github.com/Asakeron/5912947) using both options.

As the default values don't change the current behavior, I believe it's safe to assume this pull request won't cause any compatibility problems.

Thank you.
